### PR TITLE
Show repo as using R code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.html linguist-detectable=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.Rmd linguist-language=R
+*.Rmd linguist-detectable=True

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,1 @@
-*.Rmd linguist-detectable=True
-*.eps linguist-detectable=False
 *.eps linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.Rmd linguist-detectable=True
+*.eps linguist-detectable=False

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.eps linguist-vendored
+*.Rmd linguist-language=R

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.Rmd linguist-detectable=True
 *.eps linguist-detectable=False
+*.eps linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.html linguist-detectable=false
+*.Rmd linguist-language=R


### PR DESCRIPTION
Currently shows up as postscript; set up to properly show up as a repo for R code so it's easier to browse for by users.